### PR TITLE
bumped version of YoutubeExplode to 6.5.2 and AngleSharp to 1.2.0

### DIFF
--- a/SubTubular/SubTubular.csproj
+++ b/SubTubular/SubTubular.csproj
@@ -13,12 +13,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.1.2" />
+    <PackageReference Include="AngleSharp" Version="1.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Lifti.Core" Version="6.3.0" />
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-    <PackageReference Include="YoutubeExplode" Version="6.4.3" />
+    <PackageReference Include="YoutubeExplode" Version="6.5.2" />
   </ItemGroup><!--
     appends git commit hash to assembly informational version; from https://stackoverflow.com/a/45248069
     see also https://andrewlock.net/version-vs-versionsuffix-vs-packageversion-what-do-they-all-mean/ -->


### PR DESCRIPTION
closes https://github.com/h0lg/SubTubular/issues/11

fixed by bumping version